### PR TITLE
use prefix as name if missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,9 +40,16 @@ func run() error {
 			}
 
 			spec := strings.Fields(line)
+
+			prefix := spec[1]
+			name := strings.Trim(strings.Join(spec[2:], " "), "\"")
+			if name == "" {
+				name = prefix
+			}
+
 			currentSnippet = snippet{
-				Prefix: spec[1],
-				Name:   strings.Trim(strings.Join(spec[2:], " "), "\""),
+				Prefix: prefix,
+				Name:   name,
 			}
 
 			continue


### PR DESCRIPTION
since my snipmate snippets didn't have a name after the prefix, I was getting a single snippet (the last one) with an empty name

this uses the prefix as a name if no name is provided